### PR TITLE
FIX Move prophecy into non-dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,10 @@
             "TractorCow\\ClassProxy\\Tests\\": "tests/"
         }
     },
-    "require-dev": {
-        "phpunit/phpunit": "^5.7",
+    "require": {
         "phpspec/prophecy": "^1.7"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7"
     }
 }


### PR DESCRIPTION
The `ProxyClassPatch` class implements and uses some prophecy APIs, so this
dependency should not be dev-only.